### PR TITLE
Fix: Add missing install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,4 +12,11 @@ setup(
     license="MIT",
     packages=find_packages(),
     zip_safe=False,
+    install_requires=[
+        # The boto version ranges are added to support usage in
+        # procloud! Be careful when updating these!
+        "boto3 <= 1.35.36, >= 1.26.149",
+        "botocore <= 1.35.36, >= 1.26.149",
+        "requests == 2.31.0",
+        "requests-aws4auth == 1.2.3", ],
 )


### PR DESCRIPTION
Δύο ανοιχτά ζητήματα για το review:

- Έβαλα ranges για τα boto πακέτα για να είναι συμβατό με το procloud. Εν τέλει, όμως, μάλλον δεν θα χρειαστεί να το χρησιμοποιήσουμε εκεί. Άρα να κρατήσουμε τα ranges όπως τα έχω τώρα ή να το πάω πάλι σε pinned versions;
- Δεν έβαλα όλα τα πακέτα από το `requirements.txt` γιατί δεν είδα να χρησιμοποιούνται τα υπόλοιπα. Είναι outdated το `requirements.txt`; Να τα αφαιρέσουμε και εκεί;